### PR TITLE
Add `ratelimit` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Packages that extend `net/http` functionality.
 | Package      | RFCs                                              | Description                                       |
 |:-------------|:--------------------------------------------------|:--------------------------------------------------|
 | `websocket`  | [RFC6455](https://www.rfc-editor.org/rfc/rfc6455) | Implements the WebSocket protocol.                |
+| `ratelimit`  | N/A                                               | Implements HTTP rate limitng middleware.          |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/picatz/httpz
 
 go 1.19
+
+require golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/ratelimit/doc.go
+++ b/pkg/ratelimit/doc.go
@@ -1,0 +1,2 @@
+// Package ratelimit provides a basic rate limiter middleware for net/http.
+package ratelimit

--- a/pkg/ratelimit/handler.go
+++ b/pkg/ratelimit/handler.go
@@ -1,0 +1,79 @@
+package ratelimit
+
+import (
+	"net/http"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Handler is a net/http middleware that rate limits requests
+// based on the configured limiter.
+type Handler struct {
+	// Limiter is the rate limiter used to limit requests.
+	Limiter *rate.Limiter
+
+	// SetRetryAfter sets the Retry-After header on rate limited
+	// responses. If false, the header is not set.
+	SetRetryAfter bool
+
+	// DropOnLimit drops requests on rate limit instead of returning
+	// a 429 status code. If true, the request is dropped and the
+	// OnLimit handler is not called.
+	DropOnLimit bool
+
+	// OnLimit is called when a request is rate limited.
+	// If nil, http.StatusTooManyRequests (429) is returned.
+	OnLimit func(w http.ResponseWriter, r *http.Request)
+
+	// Next is the Next handler in the chain.
+	Next http.HandlerFunc
+}
+
+// ServeHTTP implements http.Handler and rate limits requests based
+// on the configured limiter.
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Limiter == nil {
+		// Check if the Next handler is set.
+		if h.Next != nil {
+			// Call the next handler.
+			h.Next(w, r)
+			return
+		}
+		return
+	}
+
+	// Check if the request is rate limited.
+	if !h.Limiter.Allow() {
+		// Check if the SetRetryAfter flag is set.
+		if h.SetRetryAfter {
+			// Set the Retry-After header based on the limiter's
+			// rate and burst. Round the duration to the nearest
+			// second.
+			w.Header().Set("Retry-After", h.Limiter.Reserve().Delay().Round(time.Second).String())
+		}
+
+		// Check if the OnLimit handler is set.
+		if h.OnLimit != nil {
+			// Call the OnLimit handler.
+			h.OnLimit(w, r)
+			return
+		}
+
+		// Return a 429 status code.
+		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+		return
+	}
+
+	// TODO: consider adding other X-RateLimit-* headers to the response, maybe
+	// based on the limiter's rate and burst.
+	//
+	// See https://tools.ietf.org/html/rfc6585#section-4
+
+	// Check if the Next handler is set.
+	if h.Next != nil {
+		// Call the next handler.
+		h.Next(w, r)
+		return
+	}
+}

--- a/pkg/ratelimit/handler_test.go
+++ b/pkg/ratelimit/handler_test.go
@@ -1,0 +1,91 @@
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/picatz/httpz/pkg/ratelimit"
+)
+
+// TestHandler tests the Handler type.
+func TestHandler(t *testing.T) {
+	// Create a new limiter that allows a single request per second.
+	limiter := rate.NewLimiter(rate.Every(1*time.Second), 1)
+
+	// Create a new handler with the limiter.
+	handler := ratelimit.Handler{
+		Limiter:       limiter,
+		SetRetryAfter: true,
+	}
+
+	// Ensure the handler allows a single request per second.
+	{
+		// Create a new request.
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// Create a new response recorder.
+		rec := httptest.NewRecorder()
+
+		// Serve the request.
+		handler.ServeHTTP(rec, req)
+
+		// Check the response status code.
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status code %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		// Create a new request.
+		req = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// Create a new response recorder.
+		rec = httptest.NewRecorder()
+
+		// Serve the request.
+		handler.ServeHTTP(rec, req)
+
+		// Check the response status code.
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("expected status code %d, got %d", http.StatusTooManyRequests, rec.Code)
+		}
+
+		// Check the Retry-After header.
+		if retryAfter := rec.Header().Get("Retry-After"); retryAfter != "1s" {
+			t.Fatalf("expected Retry-After header to be %q, got %q", "1s", retryAfter)
+		}
+
+		// Wait just over a second to allow the next request.
+		time.Sleep(2 * time.Second)
+
+		// Create a new request.
+		req = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// Create a new response recorder.
+		rec = httptest.NewRecorder()
+
+		// Serve the request.
+		handler.ServeHTTP(rec, req)
+
+		// Check the response status code.
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status code %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		// Create a new request.
+		req = httptest.NewRequest(http.MethodGet, "/", nil)
+
+		// Create a new response recorder.
+		rec = httptest.NewRecorder()
+
+		// Serve the request.
+		handler.ServeHTTP(rec, req)
+
+		// Check the response status code.
+		if rec.Code != http.StatusTooManyRequests {
+			t.Fatalf("expected status code %d, got %d", http.StatusTooManyRequests, rec.Code)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an initial implementation of a `ratelimit` package that exposes an `net/http.Handler` that can enforce a rate limit. It also provides options for setting common rate limiting headers like `Retry-After` and `X-RateLimit-Limit`.

```go
// HTTP rate limiter for 1 request per second.
handler := ratelimit.Handler{
	Limiter:       rate.NewLimiter(rate.Every(1*time.Second), 1),
	SetRetryAfter: true,
	SetXLimit:     true,
	Next:          nextHandler,
}

```